### PR TITLE
fix: normalize timestamp to UTC Z format before sending to Nomos API

### DIFF
--- a/custom_components/nomos/services.py
+++ b/custom_components/nomos/services.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timezone
 from typing import Any
 
 import aiohttp
@@ -35,7 +36,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
         """Submit an analog meter reading to Nomos."""
         subscription_id: str = call.data["subscription_id"]
         value: float = call.data["value"]
-        timestamp: str = call.data["timestamp"]
+        timestamp_raw: str = call.data["timestamp"]
+        # Nomos API requires UTC with Z suffix; normalize any tz-aware string.
+        from datetime import datetime
+        dt = datetime.fromisoformat(timestamp_raw)
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(timezone.utc)
+        timestamp = dt.strftime("%Y-%m-%dT%H:%M:%SZ")
         message: str | None = call.data.get("message")
 
         # Look up the coordinator that owns this subscription


### PR DESCRIPTION
The HA date picker produces timestamps with local tz offset (e.g. +01:00) which the Nomos API rejects. Convert to UTC and format with Z suffix.

https://claude.ai/code/session_017n7xDrgezXo682kGUtBZ7d